### PR TITLE
--debug

### DIFF
--- a/app/CommunityPartners/page.tsx
+++ b/app/CommunityPartners/page.tsx
@@ -42,24 +42,24 @@ const currentPartners: Partner[] = [
 //   }
 ];
 
-const pastPartners: Partner[] = [
-  {
-    id: 4,
-    name: "Cloud Native Hooghly",
-    logo: "/Assets/Logo/cnh_logo_stacked.png", // Using existing logo as placeholder
-    website: "https://community.cncf.io/cloud-native-hooghly",
-    description: "CNCF Hooghly Chapter, the dynamic and vibrant local community group affiliated with the prestigious Cloud Native Computing Foundation (CNCF). Our mission is to revolutionize the cloud-native landscape in the Hooghly region by fostering a platform that empowers networking, education, and collaboration.",
-    status: 'past'
-  },
-  {
-    id: 5,
-    name: "Startup Accelerator",
-    logo: "/Assets/Logo/cj_new_logo_2024.png", // Using existing logo as placeholder
-    website: "https://startupaccelerator.com",
-    description: "Helped launch numerous tech startups",
-    status: 'past'
-  }
-];
+// const pastPartners: Partner[] = [
+//   {
+//     id: 4,
+//     name: "Cloud Native Hooghly",
+//     logo: "/Assets/Logo/cnh_logo_stacked.png", // Using existing logo as placeholder
+//     website: "https://community.cncf.io/cloud-native-hooghly",
+//     description: "CNCF Hooghly Chapter, the dynamic and vibrant local community group affiliated with the prestigious Cloud Native Computing Foundation (CNCF). Our mission is to revolutionize the cloud-native landscape in the Hooghly region by fostering a platform that empowers networking, education, and collaboration.",
+//     status: 'past'
+//   },
+//   {
+//     id: 5,
+//     name: "Startup Accelerator",
+//     logo: "/Assets/Logo/cj_new_logo_2024.png", // Using existing logo as placeholder
+//     website: "https://startupaccelerator.com",
+//     description: "Helped launch numerous tech startups",
+//     status: 'past'
+//   }
+// ];
 
 export default function CommunityPartners() {
   const handlePartnerClick = (website: string) => {


### PR DESCRIPTION
This pull request modifies the handling of past partners in the `CommunityPartners` page. The `pastPartners` array has been commented out rather than removed, suggesting it may be temporarily disabled or preserved for future use.

### Changes to `CommunityPartners` page:

* The `pastPartners` array, which included details for two past partners ("Cloud Native Hooghly" and "Startup Accelerator"), has been commented out. This preserves the data in the codebase but prevents it from being used in the application at runtime.